### PR TITLE
Validation errors for haveRecord method

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -574,7 +574,7 @@ class Yii2 extends Framework implements ActiveRecord, MultiSession, PartedModule
         $record->setAttributes($attributes, false);
         $res = $record->save(false);
         if (!$res) {
-            $this->fail("Record $model was not saved");
+            $this->fail("Record $model was not saved: " . \yii\helpers\Json::encode($record->errors));
         }
         return $record->primaryKey;
     }


### PR DESCRIPTION
When haveRecord is used and it fails to create a model due to some validation, it's not obvious from the test output why.
The proposed fix will append default failure message with associated validation errors