### PR TITLE
Fix ModuleException parameters, handle undefined

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -886,13 +886,13 @@ class Yii2 extends Framework implements ActiveRecord, MultiSession, PartedModule
     public function _backupSession()
     {
         if (isset(Yii::$app) && Yii::$app->session->useCustomStorage) {
-            throw new ModuleException("Yii2 MultiSession only supports the default session backend.");
+            throw new ModuleException($this, "Yii2 MultiSession only supports the default session backend.");
         }
         return [
             'clientContext' => $this->client->getContext(),
             'headers' => $this->headers,
-            'cookie' => $_COOKIE,
-            'session' => $_SESSION,
+            'cookie' => isset($_COOKIE) ? $_COOKIE : [],
+            'session' => isset($_SESSION) ? $_SESSION : [],
         ];
     }
 


### PR DESCRIPTION
With a Docker standalone ChromeDriver setup, I am running into issues with $_SESSION being undefined in the backup function - $_COOKIE is fine in the setup but adding a check on that line for consistency. I also noticed that the ModuleException signature requires a second parameter - fixing while I'm in this section.