### PR TITLE
Update Yii2 module: use Fixtures store owner

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2/FixturesStore.php
+++ b/src/Codeception/Lib/Connector/Yii2/FixturesStore.php
@@ -11,19 +11,30 @@ class FixturesStore
     protected $data;
 
     /**
+     * @var string Class-owner of this store
+     */
+    protected $owner;
+
+    /**
      * Expects fixtures config
      *
      * FixturesStore constructor.
      * @param $data
      */
-    public function __construct($data)
+    public function __construct($data, $owner)
     {
         $this->data = $data;
+        $this->owner = $owner;
     }
 
     public function fixtures()
     {
         return $this->data;
+    }
+
+    public function getOwner()
+    {
+        return $this->owner;
     }
 
     public function globalFixtures()


### PR DESCRIPTION
Suggestion to fix #11 - Load fixtures by each test case separately.

Shortly: load fixtures and save owner of store.
This is used when `cleanup: false` and fixtures is loaded in `_fixtures` method (not by calling `haveFixtures()`) and when different test cases load different fixtures