### PR TITLE
Fix for support Instance::of in configuration

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -265,13 +265,16 @@ class Yii2 extends Client
     {
         codecept_debug('Starting application');
         $config = require($this->configFile);
-        if (!isset($config['class'])) {
-            $config['class'] = 'yii\web\Application';
+        if (isset($config['class'])) {
+            $applicationClass = $config['class'];
+            unset($config['class']);
+        } else {
+            $applicationClass = 'yii\web\Application';
         }
 
         $config = $this->mockMailer($config);
         /** @var \yii\web\Application $app */
-        Yii::$app = Yii::createObject($config);
+        Yii::$app = new $applicationClass($config);
         Yii::setLogger(new Logger());
     }
 

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -265,16 +265,13 @@ class Yii2 extends Client
     {
         codecept_debug('Starting application');
         $config = require($this->configFile);
-        if (isset($config['class'])) {
-            $applicationClass = $config['class'];
-            unset($config['class']);
-        } else {
-            $applicationClass = 'yii\web\Application';
+        if (!isset($config['class'])) {
+            $config['class'] = 'yii\web\Application';
         }
 
         $config = $this->mockMailer($config);
         /** @var \yii\web\Application $app */
-        Yii::$app = new $applicationClass($config);
+        Yii::$app = Yii::createObject($config);
         Yii::setLogger(new Logger());
     }
 

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -269,6 +269,12 @@ class Yii2 extends Client
             $config['class'] = 'yii\web\Application';
         }
 
+        if (isset($config['container']))
+        {
+            Yii::configure(Yii::$container, $config['container']);
+            unset($config['container']);
+        }
+
         $config = $this->mockMailer($config);
         /** @var \yii\web\Application $app */
         Yii::$app = Yii::createObject($config);


### PR DESCRIPTION
Using createObject with \yii\di\Instance::of in configuration does not work.
Creating an instance of the application in the suggested way solves the problem.