### PR TITLE
Application class config

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -83,6 +83,12 @@ class Yii2 extends Client
      */
     public $closeSessionOnRecreateApplication = true;
 
+    /**
+     * @var string The FQN of the application class to use. In a default Yii setup, should be either `yii\web\Application`
+     *             or `yii\console\Application`
+     */
+    public $applicationClass = null;
+
 
     private $emails = [];
 
@@ -266,7 +272,11 @@ class Yii2 extends Client
         codecept_debug('Starting application');
         $config = require($this->configFile);
         if (!isset($config['class'])) {
-            $config['class'] = 'yii\web\Application';
+            if (null !== $this->applicationClass) {
+                $config['class'] = $this->applicationClass;
+            } else {
+                $config['class'] = 'yii\web\Application';
+            }
         }
 
         if (isset($config['container']))
@@ -276,7 +286,7 @@ class Yii2 extends Client
         }
 
         $config = $this->mockMailer($config);
-        /** @var \yii\web\Application $app */
+        /** @var \yii\base\Application $app */
         Yii::$app = Yii::createObject($config);
         Yii::setLogger(new Logger());
     }

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -94,7 +94,7 @@ use yii\db\Transaction;
  *
  * By default all available methods are loaded, but you can also use the `part`
  * option to select only the needed actions and to avoid conflicts. The
- * avilable parts are:
+ * available parts are:
  *
  * * `init` - use the module only for initialization (for acceptance tests).
  * * `orm` - include only `haveRecord/grabRecord/seeRecord/dontSeeRecord` actions.

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -46,6 +46,11 @@ use yii\db\Transaction;
  * * `configFile` *required* - path to the application config file. The file
  *   should be configured for the test environment and return a configuration
  *   array.
+ * * `applicationClass` - Fully qualified class name for the application. There are
+ *   several ways to define the application class. Either via a `class` key in the Yii
+ *   config, via specifying this codeception module configuration value or let codeception
+ *   use its default value `yii\web\Application`. In a standard Yii application, this
+ *   value should be either `yii\console\Application`, `yii\web\Application` or unset.
  * * `entryUrl` - initial application url (default: http://localhost/index-test.php).
  * * `entryScript` - front script title (like: index-test.php). If not set it's
  *   taken from `entryUrl`.
@@ -178,6 +183,7 @@ class Yii2 extends Framework implements ActiveRecord, MultiSession, PartedModule
         'recreateComponents' => [],
         'recreateApplication' => false,
         'closeSessionOnRecreateApplication' => true,
+        'applicationClass' => null,
     ];
 
     protected $requiredFields = ['configFile'];


### PR DESCRIPTION
As I was testing an application, I realized that it is impossible to change the application class without creating extra config files. By checking the code, I saw that it should be possible to determine the application class by setting a root level `class` key in the application config file (e.g. `common/config/test.php`). The issue with that is `yii_test` is loading this config file as well and get a `yii\base\UnknownPropertyException` with the message 'Setting unknown property: yii\console\Application::class'.
So either you modify `yii_test` to unset the class key before creating the console application or create another config file just for codeception and define the class there.
Thus I felt, it would be more sensible to have this configuration value in the codeception module itself.