### PR TITLE
Add method to delete sent emails during tests

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -208,6 +208,15 @@ class Yii2 extends Client
     }
 
     /**
+     * Deletes all stored emails.
+     * @internal
+     */
+    public function clearEmails()
+    {
+        $this->emails = [];
+    }
+
+    /**
      * @internal
      */
     public function getComponent($name)

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -804,6 +804,15 @@ class Yii2 extends Framework implements ActiveRecord, MultiSession, PartedModule
         return end($messages);
     }
 
+    /**
+     * Deletes all sent emails.
+     * @part email
+     */
+    public function deleteSentEmails()
+    {
+        $this->client->clearEmails();
+    }
+
 
 
     /**


### PR DESCRIPTION
Please excuse me directly opening a pull request, but I found this highly helpful on my own projects and thought it might be helpful to the community as well.

This PR adds a method `deleteSentEmails()` to the module which allows clearing the email "buffer" of the Yii instance. This is helpful if you are using Specify and want to use the `seeEmailIsSent()` assertion in one specify clause and `dontSeeEmailIsSent()` in a following clause. Since the first clause sent an email, the second assertion will fail. Clearing the sent emails at the start of the second clause allows you to test properly.

---

I'm participating in hacktoberfest, so I would be very happy if you could either mark the PR with an `hacktoberfest-accepted` label, approve it or merge it before 31st October 2021 if you deem it useful :) If you don't think it is helpful, let me know and I withdraw the PR.