### PR TITLE
fix install on php8.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": ">=5.6.0 ~8.1.0",
+        "php": ">=5.6.0 <=8.1 | ~8.1.0",
         "codeception/lib-innerbrowser": "^1.0",
         "codeception/codeception": "^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": ">=5.6.0 <=8.1",
+        "php": ">=5.6.0 ~8.1.0",
         "codeception/lib-innerbrowser": "^1.0",
         "codeception/codeception": "^4.0"
     },


### PR DESCRIPTION
fix codeception/module-yii2 1.1.4 requires php >=5.6.0 <=8.1 -> your php version (8.1.1) does not satisfy that requirement