### PR TITLE
Fix warning

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -510,6 +510,10 @@ class Yii2 extends Framework implements ActiveRecord, MultiSession, PartedModule
      */
     public function grabFixtures()
     {
+        if (!$this->loadedFixtures) {
+            return [];
+        }
+
         return call_user_func_array(
             'array_merge',
             array_map( // merge all fixtures from all fixture stores


### PR DESCRIPTION
Fix warning:
```shell
Warning: array_merge() expects at least 1 parameter, 0 given
```

Inside test (empty `_fixtures()`):
```php
$this->tester->grabFixture('some');
```