### PR TITLE
Fix last commit error

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -397,8 +397,7 @@ class Yii2 extends Framework implements ActiveRecord, MultiSession, PartedModule
 
     public function _failed(TestInterface $test, $fail)
     {
-        $log = $this->yiiLogger->getAndClearLog();
-        if (! empty($log)) {
+        if ($this->yiiLogger && $log = $this->yiiLogger->getAndClearLog()) {
             $test->getMetadata()->addReport('yii-log', $log);
         }
 


### PR DESCRIPTION
Fix last commit error:
```shell
Exception 'Error' with message 'Call to a member function getAndClearLog() on null' in /srv/www/app/vendor/codeception/module-yii2/src/Codeception/Module/Yii2.php:400

Stack trace:
#0 /srv/www/app/vendor/codeception/codeception/src/Codeception/Subscriber/Module.php(90): Codeception\Module\Yii2-&gt;_failed(Object(Codeception\Test\TestCaseWrapper), Object(PHPUnit\Framework\ExpectationFailedException))
#1 /srv/www/app/vendor/symfony/event-dispatcher/EventDispatcher.php(230): Codeception\Subscriber\Module-&gt;failed(Object(Codeception\Event\FailEvent), 'test.fail', Object(Symfony\Component\EventDispatcher\EventDispatcher))
...
```