### PR TITLE
Fix wrong namespace

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -40,7 +40,7 @@ class Yii2 extends Client
     /**
      * Clean the response object by resetting specific properties via its' `clear()` method.
      * This will keep behaviors / event handlers, but could inadvertently leave some changes intact.
-     * @see \Yii\web\Response::clear()
+     * @see \yii\web\Response::clear()
      */
     const CLEAN_CLEAR = 'clear';
 


### PR DESCRIPTION
Sometimes Psalm finds a floating bug on some systems:

```
message: Class, interface or enum Yii\web\ErrorAction has wrong casing
type: InvalidClass
snippet: 'class' => yii\web\ErrorAction::class,
selected_text: yii\web\ErrorAction
```

This PR should fix the floating bug with yii\web* napespace.