### PR TITLE
InitDbFixture object cannot be overridden during FixturesStore initialization

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2/FixturesStore.php
+++ b/src/Codeception/Lib/Connector/Yii2/FixturesStore.php
@@ -29,7 +29,9 @@ class FixturesStore
     public function globalFixtures()
     {
         return [
-            InitDbFixture::class
+            'initDbFixture' => [
+                'class' => InitDbFixture::class,
+            ],
         ];
     }
 }


### PR DESCRIPTION
### Issue
There is an issue configuring component properties when the user does not use Yii2 default values during Codeception tests. The problem caused by using anonymous array value to register InitDbFixture [yii\test\InitDbFixture] component rather than using key-pair component registering.

The following attachment occurred from changing Yii default database component from `db` to something else.

<img width="746" alt="Screenshot 2023-06-15 at 16 58 15" src="https://github.com/Codeception/module-yii2/assets/1761107/fd234c39-c866-4648-82e3-5fc235ba214b">

### Solution
During FixturesStore [Codeception\Lib\Connector\Yii2\FixturesStore] initialization, its `globalFixtures()` has InitDbFixture component registering as anonymous fixture value resulting to Yii unable to merge the fixtures array in FixtureTrait [yii\test\FixtureTrait::getFixtures()].

By changing its registration from the following
```php
return [
    InitDbFixture::class
];
```
to
```php
return [
    'initDbFixture' => [
        'class' => InitDbFixture::class,
    ],
];
```
This allows the user to override component InitDbFixture default values via `_fixtures()` in test case.

### Result
Example of application using `otherDbComponent` to be main database component than Yii default `db`.
```php
// in a Cest file
public function _fixtures()
{
    return [
        // This will be merged and overridden during initialization
        'initDbFixture' => [
            'class' => \yii\test\InitDbFixture::class,
            'db' => 'otherDbComponent',
        ],
        'user' => [
            'class' => UserFixture::class,
            'db' => 'otherDbComponent',
            'dataFile' => codecept_data_dir() . 'login_data.php'
        ]
    ];
}
```