### PR TITLE
Fix parallel sessions with `$I->haveFriend()` when no session is active

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -897,7 +897,7 @@ class Yii2 extends Framework implements ActiveRecord, MultiSession, PartedModule
      */
     public function _backupSession(): array
     {
-        if (isset(Yii::$app) && Yii::$app->session->useCustomStorage) {
+        if (isset(Yii::$app) && Yii::$app->has('session', true) && Yii::$app->session->useCustomStorage) {
             throw new ModuleException($this, "Yii2 MultiSession only supports the default session backend.");
         }
         return [


### PR DESCRIPTION
When using `$I->haveFriend()`, my tests would fail with the following error.

```
[yii\base\UnknownPropertyException] Getting unknown property: yii\console\Application::session
```

This is because the code in `_backupSession()` didn't check if we actually have a `Yii::$app->session` before accessing `Yii::$app->session->useCustomStorage`.

This PR fixes this and allows me to run my tests.

See #2 and #3