### PR TITLE
Fix runtime fatal error Declaration in Yii2.php

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -480,7 +480,7 @@ class Yii2 extends Client
         return $config;
     }
 
-    public function restart()
+    public function restart(): void
     {
         parent::restart();
         $this->resetApplication();


### PR DESCRIPTION
Upgrading `symfony/browser-kit` from `v6.4.0` to `v7.0.0` getting runtime error.

```
Codeception PHP Testing Framework v5.0.12 https://stand-with-ukraine.pp.ua
PHP Fatal error:  Declaration of Codeception\Lib\Connector\Yii2::restart() must be compatible with Symfony\Component\BrowserKit\AbstractBrowser::restart(): void in /var/www/html/test/vendor/codeception/module-yii2/src/Codeception/Lib/Connector/Yii2.php on line 483

Fatal error: Declaration of Codeception\Lib\Connector\Yii2::restart() must be compatible with Symfony\Component\BrowserKit\AbstractBrowser::restart(): void in /var/www/html/test/vendor/codeception/module-yii2/src/Codeception/Lib/Connector/Yii2.php on line 483
```

Add return type of `restart` method to void to implement method `restart` in parent `AbstractBrowser` class.