### PR TITLE
Fix broken `amLoggedInAs` - method parameter is being overwritten

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -142,13 +142,13 @@ class Yii2 extends Client
             $identity = $user;
         } else {
             // class name implementing IdentityInterface
-            $identityClass = $user->identityClass;
+            $identityClass = $userComponent->identityClass;
             $identity = call_user_func([$identityClass, 'findIdentity'], $user);
             if (!isset($identity)) {
                 throw new \RuntimeException('User not found');
             }
         }
-        $user->login($identity);
+        $userComponent->login($identity);
     }
 
     /**

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -133,8 +133,8 @@ class Yii2 extends Client
     public function findAndLoginUser(int|string|IdentityInterface $user): void
     {
         $app = $this->getApplication();
-        $user = $app->get('user');
-        if (!$user instanceof User) {
+        $userComponent = $app->get('user');
+        if (!$userComponent instanceof User) {
             throw new ConfigurationException('The user component is not configured');
         }
 


### PR DESCRIPTION
Recent changes ([here](https://github.com/Codeception/module-yii2/commit/219fbd9465472077785e1a93fc01fa89489bf2cc#diff-73a2f17bdda413759cc20c4cdd039997604a9bf4cc857283d0e71d8ec6982dfaL137-R137)) introduced that bug. The newly added `$user` variable for checking if `User` component is of the right type overwrites the parameter to the method with the same name.