### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4]
 
     steps:
     - name: Checkout code

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -250,7 +250,7 @@ class Yii2 extends Client
         return $this->getApplication()->request->csrfParam;
     }
 
-    public function startApp(\yii\log\Logger $logger = null): void
+    public function startApp(?\yii\log\Logger $logger = null): void
     {
         codecept_debug('Starting application');
         $config = require($this->configFile);

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -723,11 +723,11 @@ final class Yii2 extends Framework implements ActiveRecord, MultiSession, Parted
      * $I->seeEmailIsSent(3);
      * ```
      *
-     * @param int $num
+     * @param int|null $num
      * @throws \Codeception\Exception\ModuleException
      * @part email
      */
-    public function seeEmailIsSent(int $num = null): void
+    public function seeEmailIsSent(?int $num = null): void
     {
         if ($num === null) {
             $this->assertNotEmpty($this->grabSentEmails(), 'emails were sent');


### PR DESCRIPTION
Implicitly nullable parameter types are deprecated: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types