### PR TITLE
Make TestMailer proxying

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,2 @@
+COMPOSER_HOME=~/.config/composer
+UID=1000

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 tests/_support
 tests/_output
 tests/cases/yii2-app-advanced/_data/db.sqlite
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+ARG PHP_VERSION="8.3-alpine"
+
+FROM php:$PHP_VERSION
+
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/install-php-extensions \
+    && apk add --no-cache git \
+    && install-php-extensions gd intl zip intl pcov @composer
+
+WORKDIR /var/www/html

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "codemix/yii2-localeurls": "^1.7",
         "codeception/module-asserts": ">= 3.0",
         "codeception/module-filesystem": "> 3.0",
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^1.10",
+        "yiisoft/yii2-swiftmailer": "^2.0.0"
     },
     "autoload":{
         "classmap": ["src/"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+
+  php80: &phpbase
+    user: ${UID}
+    volumes:
+      - ${COMPOSER_HOME}:/.config/composer:delegated
+      # Mount source-code for development
+      - ./:/var/www/html
+    env_file:
+      - .env
+    environment:
+      - XDEBUG_CONFIG=client_host=host.docker.internal
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    build:
+      context: ./
+      dockerfile: Dockerfile
+      args:
+        - PHP_VERSION=8.0-alpine
+    
+  php81:
+    <<: *phpbase
+    build:
+      args:
+        - PHP_VERSION=8.1-alpine
+  php82:
+    <<: *phpbase
+    build:
+      args:
+        - PHP_VERSION=8.2-alpine
+  
+  php83:
+    <<: *phpbase
+    build:
+      args:
+        - PHP_VERSION=8.3-alpine
+  php84:
+    <<: *phpbase
+    build:
+      args:
+        - PHP_VERSION=8.4-alpine

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -15,6 +15,7 @@ use yii\base\ExitException;
 use yii\base\Security;
 use yii\base\UserException;
 use yii\mail\MessageInterface;
+use yii\symfonymailer\Mailer;
 use yii\web\Application;
 use yii\web\ErrorHandler;
 use yii\web\IdentityInterface;
@@ -422,33 +423,20 @@ class Yii2 extends Client
      */
     protected function mockMailer(array $config): array
     {
-        // options that make sense for mailer mock
-        $allowedOptions = [
-            'htmlLayout',
-            'textLayout',
-            'messageConfig',
-            'messageClass',
-            'useFileTransport',
-            'fileTransportPath',
-            'fileTransportCallback',
-            'view',
-            'viewPath',
-        ];
-
         $mailerConfig = [
             'class' => TestMailer::class,
             'callback' => function (MessageInterface $message) {
                 $this->emails[] = $message;
-            }
+            },
+            'mailer' => [
+                'class' => Mailer::class,
+            ]
         ];
 
-        if (isset($config['components']['mailer']) && is_array($config['components']['mailer'])) {
-            foreach ($config['components']['mailer'] as $name => $value) {
-                if (in_array($name, $allowedOptions, true)) {
-                    $mailerConfig[$name] = $value;
-                }
-            }
+        if (isset($config['components']['mailer'])) {
+            $mailerConfig['mailer'] = $config['components']['mailer'];
         }
+
         $config['components']['mailer'] = $mailerConfig;
 
         return $config;

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -14,8 +14,8 @@ use Yii;
 use yii\base\ExitException;
 use yii\base\Security;
 use yii\base\UserException;
+use yii\helpers\ArrayHelper;
 use yii\mail\MessageInterface;
-use yii\symfonymailer\Mailer;
 use yii\web\Application;
 use yii\web\ErrorHandler;
 use yii\web\IdentityInterface;
@@ -429,13 +429,22 @@ class Yii2 extends Client
                 $this->emails[] = $message;
             },
             'mailer' => [
-                'class' => Mailer::class,
-                'transportFactory' => new NullTransportFactory()
+                'class' => \yii\symfonymailer\Mailer::class
             ]
         ];
 
-        if (isset($config['components']['mailer'])) {
-            $mailerConfig['mailer'] = $config['components']['mailer'];
+        if (isset($config['components']['mailer']) && is_array($config['components']['mailer'])) {
+            $mailerConfig['mailer'] = ArrayHelper::merge($mailerConfig['mailer'], $config['components']['mailer']);
+        }
+
+        /**
+         * Set transports only if known mailers that have this field is used
+         */
+        if ($mailerConfig['mailer']['class'] instanceof \yii\symfonymailer\Mailer) {
+            $mailerConfig['mailer']['transport'] = \Symfony\Component\Mailer\Transport\NullTransport::class;
+        }
+        if ($mailerConfig['mailer']['class'] instanceof \yii\swiftmailer\Mailer) {
+            $mailerConfig['mailer']['transport'] = \Swift_Transport_NullTransport::class;
         }
 
         $config['components']['mailer'] = $mailerConfig;

--- a/src/Codeception/Lib/Connector/Yii2.php
+++ b/src/Codeception/Lib/Connector/Yii2.php
@@ -430,6 +430,7 @@ class Yii2 extends Client
             },
             'mailer' => [
                 'class' => Mailer::class,
+                'transportFactory' => new NullTransportFactory()
             ]
         ];
 

--- a/src/Codeception/Lib/Connector/Yii2/TestMailer.php
+++ b/src/Codeception/Lib/Connector/Yii2/TestMailer.php
@@ -1,23 +1,90 @@
 <?php
 namespace Codeception\Lib\Connector\Yii2;
 
+use yii\base\UnknownMethodException;
+use yii\base\UnknownPropertyException;
+use yii\di\Instance;
 use yii\mail\BaseMailer;
+use yii\mail\MailerInterface;
 
 class TestMailer extends BaseMailer
 {
-    public $messageClass = \yii\symfonymailer\Message::class;
-
     /**
      * @var \Closure
      */
     public $callback;
+
+    /**
+     * @var string|array|MailerInterface Mailer config or component to send mail out in the end
+     */
+    public $mailer = 'mailer';
+
+    /**
+     * @inheritdoc
+     * @throws InvalidConfigException
+     */
+    public function init()
+    {
+        parent::init();
+        $this->mailer = Instance::ensure($this->mailer, MailerInterface::class);
+    }
+
+    /**
+     * @param string $name
+     * @param array $params
+     * @return mixed
+     */
+    public function __call($name, $params)
+    {
+        try {
+            return parent::__call($name, $params);
+        } catch (UnknownMethodException $e) {
+            return call_user_func_array([$this->mailer, $name], $params);
+        }
+    }
+
+    /**
+     * @param string $name
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        try {
+            return parent::__get($name);
+        } catch (UnknownPropertyException $e) {
+            return $this->mailer->{$name};
+        }
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     */
+    public function __set($name, $value)
+    {
+        try {
+            parent::__set($name, $value);
+        } catch (UnknownPropertyException $e) {
+            $this->mailer->{$name} = $value;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function compose($view = null, array $params = [])
+    {
+        $message = $this->mailer->compose($view, $params);
+        $message->mailer = $this;
+        return $message;
+    }
 
     protected function sendMessage($message)
     {
         call_user_func($this->callback, $message);
         return true;
     }
-    
+
     protected function saveMessage($message)
     {
         call_user_func($this->callback, $message);


### PR DESCRIPTION
I would like to test my application, that totally rewrites email sending logic, and found https://github.com/yiisoft/yii2/issues/14718 having same issue

this should make so that codeception proxies applications email client, so that you could use any yii2 emailing client so long as it's message extends `yii\mail\BaseMessage`