### PR TITLE
feat: allow mails to be intercepted using events

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2/TestMailer.php
+++ b/src/Codeception/Lib/Connector/Yii2/TestMailer.php
@@ -6,10 +6,11 @@ namespace Codeception\Lib\Connector\Yii2;
 
 use Closure;
 use yii\mail\BaseMailer;
+use yii\symfonymailer\Message;
 
 class TestMailer extends BaseMailer
 {
-    public $messageClass = \yii\symfonymailer\Message::class;
+    public $messageClass = Message::class;
 
     public Closure $callback;
 

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -86,6 +86,11 @@ use yii\web\IdentityInterface;
  *   changes will get discarded.
  * * `recreateApplication` - (default: `false`) whether to recreate the whole
  *   application before each request
+ * * `mailMethod` - (default: `catch`) Method for handling email via the 'mailer'
+ *   component. `ignore` will not do anything with mail, this means mails are not
+ *   inspectable by the test runner, using `before` or `after` will use mailer
+ *   events; making the mails inspectable but also allowing your default mail
+ *   handling to work
  *
  * You can use this module by setting params in your `functional.suite.yml`:
  *
@@ -187,6 +192,7 @@ class Yii2 extends Framework implements ActiveRecord, MultiSession, PartedModule
         'requestCleanMethod' => Yii2Connector::CLEAN_RECREATE,
         'recreateComponents' => [],
         'recreateApplication' => false,
+        'mailMethod' => Yii2Connector::MAIL_CATCH,
         'closeSessionOnRecreateApplication' => true,
         'applicationClass' => null,
     ];
@@ -287,6 +293,12 @@ class Yii2 extends Framework implements ActiveRecord, MultiSession, PartedModule
             throw new ModuleConfigException(
                 self::class,
                 "The response clean method must be one of: " . $validMethods
+            );
+        }
+        if (!in_array($this->config['mailMethod'], Yii2Connector::MAIL_METHODS, true)) {
+            throw new ModuleConfigException(
+                self::class,
+                "The mail method must be one of: " . $validMethods
             );
         }
         if (!in_array($this->config['requestCleanMethod'], Yii2Connector::CLEAN_METHODS, true)) {


### PR DESCRIPTION
Alternative for #117.

@mikk150 could you give this a go?
The idea behind this PR is to alternatively allow you to use the `beforeSend` or `afterSend` events for logging mails.
This should work by just setting a configuration in the module config; set `mailMethod` to `before` in the codeption config.

Let me know what you think; thanks for your contribution in #117 and bringing this feature to Codeception.