### PR TITLE
Remove multi session

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -13,13 +13,10 @@ use Codeception\Lib\Connector\Yii2\Logger;
 use Codeception\Lib\Connector\Yii2\TransactionForcer;
 use Codeception\Lib\Framework;
 use Codeception\Lib\Interfaces\ActiveRecord;
-use Codeception\Lib\Interfaces\MultiSession;
 use Codeception\Lib\Interfaces\PartedModule;
 use Codeception\TestInterface;
 use ReflectionClass;
 use RuntimeException;
-use Symfony\Component\BrowserKit\CookieJar;
-use Symfony\Component\BrowserKit\History;
 use Yii;
 use yii\base\Security;
 use yii\db\ActiveQueryInterface;
@@ -29,7 +26,6 @@ use yii\mail\BaseMessage;
 use yii\mail\MessageInterface;
 use yii\test\Fixture;
 use yii\web\Application;
-use yii\web\Application as WebApplication;
 use yii\web\IdentityInterface;
 
 /**
@@ -885,6 +881,4 @@ final class Yii2 extends Framework implements ActiveRecord, PartedModule
 
         $_SERVER = $this->server;
     }
-
-
 }

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -26,7 +26,6 @@ use yii\helpers\Url;
 use yii\mail\BaseMessage;
 use yii\mail\MessageInterface;
 use yii\test\Fixture;
-use yii\web\Application as WebApplication;
 use yii\web\IdentityInterface;
 
 /**


### PR DESCRIPTION
This removes multi session support since it is broken (#114), and cannot reasonably be fixed given Yii's constraints.

This will be part of next major release.

Edit: this will only be merged after the CS changes are merged; so for review only review this commit: https://github.com/Codeception/module-yii2/pull/124/commits/8c6b44b5511e15b4ff96a7b15e376beb00f8b0a3