### PR TITLE
fix initial loading of fixtures for mongodb #137, #28

### DIFF
--- a/src/Codeception/Lib/Connector/Yii2/FixturesStore.php
+++ b/src/Codeception/Lib/Connector/Yii2/FixturesStore.php
@@ -15,7 +15,8 @@ final class FixturesStore
      * Expects fixtures config
      */
     public function __construct(
-        protected mixed $data
+        protected mixed $data,
+        private array $databaseComponents = ['db']
     ) {
     }
 
@@ -29,10 +30,13 @@ final class FixturesStore
      */
     public function globalFixtures(): array
     {
-        return [
-            'initDbFixture' => [
+        $return = [];
+        foreach($this->databaseComponents as $databaseComponent){
+            $return['initDbFixture-'.$databaseComponent] = [
                 'class' => InitDbFixture::class,
-            ],
-        ];
+                'db' => $databaseComponent
+            ];
+        }
+        return $return;
     }
 }

--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -93,6 +93,8 @@ use yii\web\IdentityInterface;
  *   inspectable by the test runner, using `before` or `after` will use mailer
  *   events; making the mails inspectable but also allowing your default mail
  *   handling to work
+ * * `databaseComponents` = (default: `['db']`) Used to specify components of
+ *   DB type. Need to be overridden when `yii\db` is not used.
  *
  * You can use this module by setting params in your `functional.suite.yml`:
  *
@@ -237,6 +239,7 @@ final class Yii2 extends Framework implements ActiveRecord, PartedModule
         'mailMethod' => Yii2Connector::MAIL_CATCH,
         'closeSessionOnRecreateApplication' => true,
         'applicationClass' => null,
+        'databaseComponents' => ['db'],
     ];
 
     /**
@@ -560,7 +563,7 @@ final class Yii2 extends Framework implements ActiveRecord, PartedModule
         if (empty($fixtures)) {
             return;
         }
-        $fixturesStore = new Yii2Connector\FixturesStore($fixtures);
+        $fixturesStore = new Yii2Connector\FixturesStore($fixtures, $this->config['databaseComponents']);
         $fixturesStore->unloadFixtures();
         $fixturesStore->loadFixtures();
         $this->loadedFixtures[] = $fixturesStore;


### PR DESCRIPTION
Made it configurable to set which db's fixtures get initialized.
Fixes #137, #28.

FYI - @SamMousa - Please have a look.

Thanks,
Sam