### PR TITLE
Fix missing recreateComponents in configureClient() breaks tests after v2 upgrade

### DIFF
--- a/src/Codeception/Module/Yii2.php
+++ b/src/Codeception/Module/Yii2.php
@@ -374,6 +374,7 @@ final class Yii2 extends Framework implements ActiveRecord, PartedModule
         $client->closeSessionOnRecreateApplication = $settings['closeSessionOnRecreateApplication'];
         $client->applicationClass = $settings['applicationClass'];
         $client->mailMethod = $settings['mailMethod'];
+        $client->recreateComponents = $settings['recreateComponents'];
         $client->resetApplication();
     }
 


### PR DESCRIPTION
During the development of v2, configureClient() was refactored to stop automatically populating properties based on the settings array and instead assign them manually. The recreateComponents property was omitted in this process, causing all tests that rely on this behavior to fail after upgrading this library from v1 to v2 